### PR TITLE
fix: fallback to default renderer if language is not indicated

### DIFF
--- a/src/Markdig.SyntaxHighlighting.Tests/IntegrationTests.cs
+++ b/src/Markdig.SyntaxHighlighting.Tests/IntegrationTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Markdig.SyntaxHighlighting.Tests
+{
+    public class IntegrationTests
+    {
+
+        [Fact]
+        public void ShouldUseDefaultRendererIfLanguageIsNotIndicated() {
+            string testString = @"
+# This is a test
+
+```
+{
+    ""jsonProperty"": 1
+}
+```";
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseSyntaxHighlighting()
+                .Build();
+            var html = Markdown.ToHtml(testString, pipeline);
+            Assert.True(html.Contains("<pre><code>"));
+            Assert.True(html.Contains("jsonProperty"));
+            Assert.False(html.Contains("lang-"));
+        }
+
+        [Fact]
+        public void ShouldColorizeSyntaxWhenLanguageIsIndicated()
+        {
+            string testString = @"
+# This is a test
+
+```json
+{
+    ""jsonProperty"": 1
+}
+```";
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseSyntaxHighlighting()
+                .Build();
+            var html = Markdown.ToHtml(testString, pipeline);
+            Assert.True(html.Contains("<div"));
+            Assert.True(html.Contains("jsonProperty"));
+            Assert.True(html.Contains("lang-"));
+        }
+
+    }
+}

--- a/src/Markdig.SyntaxHighlighting.Tests/Markdig.SyntaxHighlighting.Tests.csproj
+++ b/src/Markdig.SyntaxHighlighting.Tests/Markdig.SyntaxHighlighting.Tests.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Example\CodeSample.cs" />
+    <Compile Include="IntegrationTests.cs" />
     <Compile Include="LanguageTypeAdapterTests.cs" />
     <Compile Include="SyntaxHighlightingExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -25,6 +25,11 @@ namespace Markdig.SyntaxHighlighting {
             var attributes = obj.TryGetAttributes() ?? new HtmlAttributes();
 
             var languageMoniker = fencedCodeBlock.Info.Replace(parser.InfoPrefix, string.Empty);
+            if (string.IsNullOrEmpty(languageMoniker)) {
+                _underlyingRenderer.Write(renderer, obj);
+                return;
+            }
+
             attributes.AddClass($"lang-{languageMoniker}");
             attributes.Classes.Remove($"language-{languageMoniker}");
 


### PR DESCRIPTION
We were getting `ArgumentException` when using your extension on fenced blocks lacking language indication:

```
System.ArgumentException
The languageId argument value must not be empty.
Parameter name: languageId
   at ColorCode.Common.Guard.ArgNotNullAndNotEmpty(String arg, String paramName)
   at ColorCode.Common.LanguageRepository.FindById(String languageId)
   at Markdig.SyntaxHighlighting.LanguageTypeAdapter.Parse(String id, String firstLine) in C:\work\Markdig.SyntaxHighlighting\src\Markdig.SyntaxHighlighting\LanguageTypeAdapter.cs:line 35
   at Markdig.SyntaxHighlighting.SyntaxHighlightingCodeBlockRenderer.ApplySyntaxHighlighting(String languageMoniker, String firstLine, String code) in C:\work\Markdig.SyntaxHighlighting\src\Markdig.SyntaxHighlighting\SyntaxHighlightingCodeBlockRenderer.cs:line 54
   at Markdig.SyntaxHighlighting.SyntaxHighlightingCodeBlockRenderer.Write(HtmlRenderer renderer, CodeBlock obj) in C:\work\Markdig.SyntaxHighlighting\src\Markdig.SyntaxHighlighting\SyntaxHighlightingCodeBlockRenderer.cs:line 46
   at Markdig.Renderers.RendererBase.Write[T](T obj)
   at Markdig.Renderers.RendererBase.WriteChildren(ContainerBlock containerBlock)
   at Markdig.Renderers.RendererBase.Write[T](T obj)
   at Markdig.Renderers.TextRendererBase.Render(MarkdownObject markdownObject)
   at Markdig.Markdown.ToHtml(String markdown, TextWriter writer, MarkdownPipeline pipeline)
   at Markdig.Markdown.ToHtml(String markdown, MarkdownPipeline pipeline)
   at Markdig.SyntaxHighlighting.Tests.IntegrationTests.ShouldUseDefaultRendererIfLanguageIsNotIndicated() in C:\work\Markdig.SyntaxHighlighting\src\Markdig.SyntaxHighlighting.Tests\IntegrationTests.cs:line 27
```


This small change is a fix for that to use the default renderer instead when in that case.

I included 2 integration tests.