### PR TITLE
Fix "Setup not implemented" issue with Markdig 0.11.0.0

### DIFF
--- a/src/Markdig.SyntaxHighlighting.Tests/Markdig.SyntaxHighlighting.Tests.csproj
+++ b/src/Markdig.SyntaxHighlighting.Tests/Markdig.SyntaxHighlighting.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>Markdig.SyntaxHighlighting.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,8 +41,8 @@
       <HintPath>..\packages\ColorCode.Portable.1.0.3\lib\portable45-net45+win8+wp8+wpa81\ColorCode.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Markdig">
-      <HintPath>..\packages\Markdig.0.7.3\lib\portable40-net40+sl5+win8+wp8+wpa81\Markdig.dll</HintPath>
+    <Reference Include="Markdig, Version=0.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.11.0\lib\net40\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.5.16.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.5.16\lib\net45\Moq.dll</HintPath>
@@ -104,7 +107,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Markdig.SyntaxHighlighting.Tests/SyntaxHighlightingExtensionsTests.cs
+++ b/src/Markdig.SyntaxHighlighting.Tests/SyntaxHighlightingExtensionsTests.cs
@@ -15,10 +15,11 @@ namespace Markdig.SyntaxHighlighting.Tests {
             var extension = new SyntaxHighlightingExtension();
             var writer = new StringWriter();
             var markdownRenderer = new HtmlRenderer(writer);
+
             var oldRendererCount = markdownRenderer.ObjectRenderers.Count;
             Assert.Equal(1,
                 markdownRenderer.ObjectRenderers.FindAll(x => x.GetType() == typeof(CodeBlockRenderer)).Count);
-            extension.Setup(markdownRenderer);
+            extension.Setup(null, markdownRenderer);
             Assert.Equal(0,
                 markdownRenderer.ObjectRenderers.FindAll(x => x.GetType() == typeof(CodeBlockRenderer)).Count);
             Assert.Equal(1,
@@ -39,7 +40,7 @@ namespace Markdig.SyntaxHighlighting.Tests {
             var writer = new StringWriter();
             var markdownRenderer = new HtmlRenderer(writer);
             markdownRenderer.ObjectRenderers.RemoveAll(x => true);
-            extension.Setup(markdownRenderer);
+            extension.Setup(null, markdownRenderer);
             Assert.Equal(1, markdownRenderer.ObjectRenderers.Count);
         }
 
@@ -61,14 +62,14 @@ namespace Markdig.SyntaxHighlighting.Tests {
             var writer = new StringWriter();
             var markdownRenderer = new FakeRenderer(writer);
             var oldRendererCount = markdownRenderer.ObjectRenderers.Count;
-            extension.Setup(markdownRenderer);
+            extension.Setup(null, markdownRenderer);
             Assert.Equal(oldRendererCount, markdownRenderer.ObjectRenderers.Count);
         }
 
         [Fact]
         public void ThrowsIfRendererIsNull() {
             var extension = new SyntaxHighlightingExtension();
-            var extensionSetup = new Action(() => extension.Setup((IMarkdownRenderer) null));
+            var extensionSetup = new Action(() => extension.Setup(null, null));
             Assert.Throws<ArgumentNullException>(extensionSetup);
         }
     }

--- a/src/Markdig.SyntaxHighlighting.Tests/packages.config
+++ b/src/Markdig.SyntaxHighlighting.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
   <package id="ColorCode.Portable" version="1.0.3" targetFramework="net461" />
+  <package id="Markdig" version="0.11.0" targetFramework="net461" />
   <package id="Moq" version="4.5.16" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
@@ -10,4 +10,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net461" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net461" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/Markdig.SyntaxHighlighting/Markdig.SyntaxHighlighting.csproj
+++ b/src/Markdig.SyntaxHighlighting/Markdig.SyntaxHighlighting.csproj
@@ -48,9 +48,8 @@
       <HintPath>..\packages\ColorCode.Portable.1.0.3\lib\portable45-net45+win8+wp8+wpa81\ColorCode.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Markdig, Version=0.7.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.0.7.3\lib\portable40-net40+sl5+win8+wp8+wpa81\Markdig.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Markdig, Version=0.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.11.0\lib\portable40-net40+sl5+win8+wp8+wpa81\Markdig.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtension.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtension.cs
@@ -6,7 +6,7 @@ namespace Markdig.SyntaxHighlighting {
     public class SyntaxHighlightingExtension : IMarkdownExtension {
         public void Setup(MarkdownPipelineBuilder pipeline) {}
 
-        public void Setup(IMarkdownRenderer renderer) {
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) {
             if (renderer == null) {
                 throw new ArgumentNullException(nameof(renderer));
             }

--- a/src/Markdig.SyntaxHighlighting/packages.config
+++ b/src/Markdig.SyntaxHighlighting/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="ColorCode.Portable" version="1.0.3" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Markdig" version="0.7.3" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Markdig" version="0.11.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
This PR fixes issue #2 which breaks this package with the latest version of Markdig (0.11.0.0). The extension interface had changed slightly and needed updating.

- Updated to latest version of Markdig
- Fixed invalid implementation
- Updated tests
- Added xunit VS test runner