### PR TITLE
Handle unrecognised languages, e.g. Diagrams/mermaid

### DIFF
--- a/src/Markdig.SyntaxHighlighting.Tests/SyntaxHighlightingCodeBlockRendererTests.cs
+++ b/src/Markdig.SyntaxHighlighting.Tests/SyntaxHighlightingCodeBlockRendererTests.cs
@@ -14,9 +14,9 @@ namespace Markdig.SyntaxHighlighting.Tests {
 var desktop = Environment.SpecialFolder.DesktopDirectory;
 ```";
 
-        private static FencedCodeBlock GetFencedCodeBlock() {
+        private static FencedCodeBlock GetFencedCodeBlock(string language = "language-csharp") {
             return new FencedCodeBlock(new FencedCodeBlockParser()) {
-                Info = "language-csharp",
+                Info = language,
                 Lines = new StringLineGroup(3) {
                     new StringSlice("```csharp"),
                     new StringSlice("var desktop = Environment.SpecialFolder.DesktopDirectory;"),
@@ -40,6 +40,21 @@ var desktop = Environment.SpecialFolder.DesktopDirectory;
             var builder = new StringBuilder();
             var markdownRenderer = new HtmlRenderer(new StringWriter(builder));
             var codeBlock = GetFencedCodeBlock();
+            renderer.Write(markdownRenderer, codeBlock);
+            Assert.Contains("<div", builder.ToString());
+            Assert.Contains("</div>", builder.ToString());
+        }
+
+        [Fact]
+        public void DivWrittenUnrecognisedLanguage()
+        {
+            var underlyingRendererMock = new Mock<CodeBlockRenderer>();
+            underlyingRendererMock
+                .Setup(x => x.Write(It.IsAny<HtmlRenderer>(), It.IsAny<CodeBlock>()));
+            var renderer = new SyntaxHighlightingCodeBlockRenderer(underlyingRendererMock.Object);
+            var builder = new StringBuilder();
+            var markdownRenderer = new HtmlRenderer(new StringWriter(builder));
+            var codeBlock = GetFencedCodeBlock("language-made-up-language"); //
             renderer.Write(markdownRenderer, codeBlock);
             Assert.Contains("<div", builder.ToString());
             Assert.Contains("</div>", builder.ToString());

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -52,6 +52,11 @@ namespace Markdig.SyntaxHighlighting {
         private static string ApplySyntaxHighlighting(string languageMoniker, string firstLine, string code) {
             var languageTypeAdapter = new LanguageTypeAdapter();
             var language = languageTypeAdapter.Parse(languageMoniker, firstLine);
+
+            if (language == null) { //handle unrecognised language formats, e.g. when using mermaid diagrams
+                return code;
+            }
+
             var codeBuilder = new StringBuilder();
             var codeWriter = new StringWriter(codeBuilder);
             var styleSheet = StyleSheets.Default;


### PR DESCRIPTION
When using the syntax highlighting extension if the user enters an unrecognised/unsupported language the extension throws an exception.

These cases are now handled, and unhighlighted code is simply returned. In my case, I need to use the Diagram support offered by Markdig which requires syntax as follows (mermaid: https://github.com/knsv/mermaid)

`````
```mermaid

[...]

```
`````

As above, because 'mermaid' was unrecognised this would break the extension. 