### PR TITLE
Don't put redundant trailing new line in code blocks

### DIFF
--- a/src/Markdig.SyntaxHighlighting.Tests/Example/expected.html
+++ b/src/Markdig.SyntaxHighlighting.Tests/Example/expected.html
@@ -27,7 +27,6 @@
         <span style="color:Blue;">string</span> GetSetting(<span style="color:Blue;">string</span> appSetting);
     }
 }
-
 </pre></div>
 </div>
 

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -78,9 +78,11 @@ namespace Markdig.SyntaxHighlighting {
 
                 if (firstLine == null) {
                     firstLine = lineText;
+                } else {
+                    code.AppendLine();
                 }
 
-                code.AppendLine(lineText);
+                code.Append(lineText);
             }
             return code.ToString();
         }


### PR DESCRIPTION
Original Markdig codeblocks don't add an extra new line in the end, but this extension does.
This PR fixes this issue and also updates the tests to accommodate.
Fixes #5