### PR TITLE
Support custom stylesheets

### DIFF
--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -9,9 +9,11 @@ using Markdig.Syntax;
 namespace Markdig.SyntaxHighlighting {
     public class SyntaxHighlightingCodeBlockRenderer : HtmlObjectRenderer<CodeBlock> {
         private readonly CodeBlockRenderer _underlyingRenderer;
+        private readonly IStyleSheet _customCss;
 
-        public SyntaxHighlightingCodeBlockRenderer(CodeBlockRenderer underlyingRenderer = null) {
+        public SyntaxHighlightingCodeBlockRenderer(CodeBlockRenderer underlyingRenderer = null, IStyleSheet customCss = null) {
             _underlyingRenderer = underlyingRenderer ?? new CodeBlockRenderer();
+            _customCss = customCss;
         }
 
         protected override void Write(HtmlRenderer renderer, CodeBlock obj) {
@@ -49,7 +51,7 @@ namespace Markdig.SyntaxHighlighting {
             renderer.WriteLine("</div>");
         }
 
-        private static string ApplySyntaxHighlighting(string languageMoniker, string firstLine, string code) {
+        private string ApplySyntaxHighlighting(string languageMoniker, string firstLine, string code) {
             var languageTypeAdapter = new LanguageTypeAdapter();
             var language = languageTypeAdapter.Parse(languageMoniker, firstLine);
 
@@ -59,7 +61,7 @@ namespace Markdig.SyntaxHighlighting {
 
             var codeBuilder = new StringBuilder();
             var codeWriter = new StringWriter(codeBuilder);
-            var styleSheet = StyleSheets.Default;
+            var styleSheet = _customCss ?? StyleSheets.Default;
             var colourizer = new CodeColorizer();
             colourizer.Colorize(code, language, Formatters.Default, styleSheet, codeWriter);
             return codeBuilder.ToString();

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtension.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtension.cs
@@ -1,9 +1,17 @@
 ﻿using System;
+using ColorCode;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 
 namespace Markdig.SyntaxHighlighting {
     public class SyntaxHighlightingExtension : IMarkdownExtension {
+        private readonly IStyleSheet _customCss;
+
+        public SyntaxHighlightingExtension(IStyleSheet customCss = null)
+        {
+            _customCss = customCss;
+        }
+
         public void Setup(MarkdownPipelineBuilder pipeline) {}
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) {
@@ -22,7 +30,7 @@ namespace Markdig.SyntaxHighlighting {
             }
 
             htmlRenderer.ObjectRenderers.AddIfNotAlready(
-                new SyntaxHighlightingCodeBlockRenderer(originalCodeBlockRenderer));
+                new SyntaxHighlightingCodeBlockRenderer(originalCodeBlockRenderer, _customCss));
         }
     }
 }

--- a/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtensions.cs
+++ b/src/Markdig.SyntaxHighlighting/SyntaxHighlightingExtensions.cs
@@ -1,7 +1,9 @@
-﻿namespace Markdig.SyntaxHighlighting {
+﻿using ColorCode;
+
+namespace Markdig.SyntaxHighlighting {
     public static class SyntaxHighlightingExtensions {
-        public static MarkdownPipelineBuilder UseSyntaxHighlighting(this MarkdownPipelineBuilder pipeline) {
-            pipeline.Extensions.Add(new SyntaxHighlightingExtension());
+        public static MarkdownPipelineBuilder UseSyntaxHighlighting(this MarkdownPipelineBuilder pipeline, IStyleSheet customCss = null) {
+            pipeline.Extensions.Add(new SyntaxHighlightingExtension(customCss));
             return pipeline;
         }
     }


### PR DESCRIPTION
The following code enables user to provide a custom `IStylesheet` instance instead of using the default ColorCode stylesheet.